### PR TITLE
isg-503: remove led from coffee file

### DIFF
--- a/isg-503.coffee
+++ b/isg-503.coffee
@@ -32,7 +32,6 @@ module.exports =
 		windows: 'https://www.balena.io/docs/learn/getting-started/isg-503/nodejs/'
 		osx: 'https://www.balena.io/docs/learn/getting-started/isg-503/nodejs/'
 		linux: 'https://www.balena.io/docs/learn/getting-started/isg-503/nodejs/'
-	supportsBlink: true
 
 	options: [ networkOptions.group ]
 


### PR DESCRIPTION
Because LED is not specified in
the supervisor config.

Changelog-entry: isg-503: remove led from coffee file
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Fixes https://github.com/balena-os/balena-isg/issues/11