### PR TITLE
flowzone: remove ESR pattern from pull_request_target

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -12,7 +12,6 @@ on:
     branches:
       - "main"
       - "master"
-      - '20[0-9][0-9].[0-1]?[1470].x'
 
 jobs:
   flowzone:


### PR DESCRIPTION
Backporting to ESR branches hits a flowzone error as both pull_request
and pull_request_target run and this only works for master.

Removing the pull_request_target run for ESR branches fixes this, but
also removes the possibility of external pull requests into ESR branches,
which we don't actually need.

[skip ci]

Changelog-entry: Remove pull_request_target event run for ESR targets
Signed-off-by: Alex Gonzalez <alexg@balena.io>
